### PR TITLE
Add Captains Log String Method to Time

### DIFF
--- a/lib/stardate.rb
+++ b/lib/stardate.rb
@@ -13,6 +13,10 @@ module Stardate
       seconds = self - t2          # seconds passed since the beginning of the day
       ((self.year - YEAR_O) + days / YEAR_DURATION + seconds / (YEAR_DURATION * 24 * 3600)) * 1000
     end
+    
+    def to_captains_log
+      "Captain's log, stardate #{to_stardate}..."
+    end
   end
 
   module SFloat


### PR DESCRIPTION
I frequently find myself using the same line. I've added a convenience method to generate the line for me so what I can simply read it off. This new method implements the `STime#to_stardate` method that previously existed.
